### PR TITLE
Beheer: update status van beheermodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Concept voor het Generiek beheermodel voor de verzameling van API standaarden
-
-> Dit is een concept
+# Generiek beheermodel voor de verzameling van API standaarden
 
 De basis is het [BOMOS template beheermodel](https://github.com/Logius-standaarden/BOMOS-voorbeeld-beheermodel).
 Het is aangevuld met een aantal standaard bijlagen die vooral het operationele proces beschrijven (Respec, Github, SEMVER).

--- a/ch01_Inleiding.md
+++ b/ch01_Inleiding.md
@@ -54,13 +54,10 @@ Ontwikkelaars kunnen deze REST-API's bevragen vanuit de gangbare programmeertale
 
 ### Status
 
-De statussen van de verschillende API standaarden zijn in de standaarden zelf vastgelegd. De Status van dit beheermodel is als volgt:
-
-| Gremium | status | toelichting |
-| ------- | ------ | ----------- |
-|Technisch Overleg | Concept akkoord | Operationeel gezien wordt deze nieuwe versie van het beheermodel besproken in de Technische overleggen die er voor de verschillende standaarden zijn. De concepten die in dit beheermodel worden gebundeld zijn op zich allemaal al akkoord. Het gehele definitieve document nog niet. |
-|Mido|In behandeling|Het algemene Logius beheermodel waarop dit beheermodel is gebaseerd is al akkoord. De vraag ligt voor bij de PTGU om ook voor de API standaarden dit beheermodel te gaan volgen.|
-|Forum Standaardisatie|Deels in behandeling|De ADR wordt als eerste opnieuw aangeboden bij het Forum en daar zal het beheermodel in worden meegenomen. Daarna volgt OAuth en dan OIDC|
+De statussen van de verschillende API standaarden zijn in de standaarden zelf vastgelegd.
+Dit beheermodel is initieel goedgekeurd in het Technisch Overleg, waarna het beheermodel is ingediend bij Mido en Forum Standaardisatie in combinatie met het indienen van de ADR als standaard.
+Met het indienen van versie 2.0 van de ADR standaard zijn tevens de beheermodelen van ADR en oAuth (die hadden een apart beheermodel) samengevoegd met dit beheermodel.
+Ook deze samenvoeging is goedgekeurd en de kopieën zijn daarom nu gearchiveerd.
 
 ## BOMOS
 

--- a/ch01_Inleiding.md
+++ b/ch01_Inleiding.md
@@ -56,7 +56,7 @@ Ontwikkelaars kunnen deze REST-API's bevragen vanuit de gangbare programmeertale
 
 De statussen van de verschillende API standaarden zijn in de standaarden zelf vastgelegd.
 Dit beheermodel is initieel goedgekeurd in het Technisch Overleg, waarna het beheermodel is ingediend bij Mido en Forum Standaardisatie in combinatie met het indienen van de ADR als standaard.
-Met het indienen van versie 2.0 van de ADR standaard zijn tevens de beheermodelen van ADR en oAuth (die hadden een apart beheermodel) samengevoegd met dit beheermodel.
+Met het indienen van versie 2.0 van de ADR standaard zijn tevens de beheermodelen van ADR en OAuth (die hadden een apart beheermodel) samengevoegd met dit beheermodel.
 Ook deze samenvoeging is goedgekeurd en de kopieën zijn daarom nu gearchiveerd.
 
 ## BOMOS

--- a/ch02_Strategie.md
+++ b/ch02_Strategie.md
@@ -166,9 +166,8 @@ Logius de aanvraag.
 
 ## Financiering
 
-Het beheer van de API Standaarden wordt gefinancierd door min. BZK voor
-een initiële periode van tenminste drie jaar (2020-2023) om gebruikers
-het vertrouwen te geven dat er geen desinvesteringen worden gedaan bij
-het implementeren van de standaard. Na drie jaar wordt de financiering
-verlengd als blijkt dat het nut van en de behoefte aan de standaard
-nog aanwezig is.
+Het beheer van de API Standaarden werd initieel gefinancierd door min. BZK voor
+een periode van drie jaar (2020-2023) om gebruikers het vertrouwen te geven dat
+er geen desinvesteringen worden gedaan bij het implementeren van de standaarden.
+Na die drie jaar werd de financiering verlengd, aangezien het nut en de behoefte
+aan de standaarden was aangetoond.


### PR DESCRIPTION
Zowel de financiering en status van het beheermodel was niet meer geupdate sinds de initiele goedkeuring en latere wijzigingen wat betreft kopieën van
het beheermodel voor de ADR en oAuth standaarden.